### PR TITLE
fix rebate info authority for claim

### DIFF
--- a/programs/rebate_manager/src/instructions/admin/create_rebate_info.rs
+++ b/programs/rebate_manager/src/instructions/admin/create_rebate_info.rs
@@ -24,8 +24,9 @@ pub struct CreateRebateInfo<'info> {
         space = 8 + RebateInfo::INIT_SPACE,
         seeds = [
           REBATEINFO_SEED.as_bytes(),
+          authority.key().as_ref(),
           rebate_manager.key().as_ref(),
-          rebate_authority.key().as_ref()
+          rebate_authority.key().as_ref(),
         ],
        bump)]
     pub rebate_info: Account<'info, RebateInfo>,

--- a/programs/rebate_manager/src/instructions/claim_rebate_fee.rs
+++ b/programs/rebate_manager/src/instructions/claim_rebate_fee.rs
@@ -24,6 +24,7 @@ pub struct ClaimRebateFee<'info> {
         has_one = rebate_manager,
         has_one = rebate_authority,
         constraint = rebate_info.authority == rebate_manager.authority
+                  || rebate_manager.admin_authority.contains(&rebate_info.authority),
     )]
     pub rebate_info: Account<'info, RebateInfo>,
 


### PR DESCRIPTION
PR for audit issue 17

https://github.com/sherlock-audit/2024-08-woofi-solana-deployment-judging/issues/17

1. add authority key in seeds
2. add  admin authority check when claim
